### PR TITLE
Adapt for empty data and one docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,13 @@ FROM rocker/tidyverse
 
 WORKDIR /home/fr_covidata_engine
 
-RUN apt update -y && apt install -y \
- libcurl4-openssl-dev
+RUN apt update -y && apt install -y libcurl4-openssl-dev
 
-#install necessary libraries
+# install necessary libraries
 RUN R -e "install.packages(c('tidyverse', 'sendmailR', 'dotenv', 'REDCapR', 'RCurl', 'checkmate', 'openxlsx'))"
 
-#set the unix commands to run the app
-CMD R -e "source('load_results_into_survey_project.R')"
+ADD load*.R /home/fr_covidata_engine/
+ADD functions.R /home/fr_covidata_engine/
+
+# Note where we are and what is there
+CMD pwd && ls -AlhF ./

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ and run the script using docker with a command something like this:
 
 `docker run --rm --env-file <path_to_dir_full_of_env_files>/fr_dev.env fr_covidata_engine_all Rscript load_results_into_survey_project.R`
 
+Example cron scripts that could run the containers on a regular basis are provided in [./examples/*.cron](./examples/)
+
 
 ## Testing workflows
 

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ The primary ETL script is [`load_results_into_survey_project.R`](load_results_in
 
 To build the image and run the report using docker within the project directory do:
 
-`docker build -t <image_name> .`
+`docker build -t fr_covidata_engine_all .`
 
-and run the report using docker within the project directory like this:
+and run the script using docker with a command something like this:
 
-`docker run --env-file .env -v path/from/host:/home/fr_covidata_engine <image_name>`
+`docker run --rm --env-file <path_to_dir_full_of_env_files>/fr_dev.env fr_covidata_engine_all Rscript load_results_into_survey_project.R`
 
 
 ## Testing workflows

--- a/examples/fr_covidata_engine_pky_development.cron
+++ b/examples/fr_covidata_engine_pky_development.cron
@@ -1,8 +1,8 @@
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
-# Use appointments to create fake lab results every minute
-# Load fake lab results into the PKY survey and serial projects every two minutes
-* * * * *   root /usr/bin/docker run --rm -it --env-file /ctsit/fr_covidata_engine/pky_dev.env fr_covidata_engine Rscript load_fake_data_into_upload.R
-* * * * *   root /usr/bin/docker run --rm -it --env-file /ctsit/fr_covidata_engine/pky_dev.env fr_covidata_engine Rscript load_fake_data_from_serial_into_upload.R
-*/2 * * * * root /usr/bin/docker run --rm -it --env-file /ctsit/fr_covidata_engine/pky_dev.env fr_covidata_engine Rscript load_results_into_pky_projects.R
+# Use appointments to create fake lab results every 3rd minute
+# Load fake lab results into the PKY survey and serial projects every 3rd minute
+0-57/3 * * * * root /usr/bin/docker run --rm --env-file /ctsit/fr_covidata_engine/pky_dev.env fr_covidata_engine_all Rscript load_fake_data_into_upload.R
+1-58/3 * * * * root /usr/bin/docker run --rm --env-file /ctsit/fr_covidata_engine/pky_dev.env fr_covidata_engine_all Rscript load_results_into_pky_projects.R
+2-59/3 * * * * root /usr/bin/docker run --rm --env-file /ctsit/fr_covidata_engine/pky_dev.env fr_covidata_engine_all Rscript load_fake_data_from_serial_into_upload.R

--- a/examples/fr_covidata_engine_pky_development.cron
+++ b/examples/fr_covidata_engine_pky_development.cron
@@ -1,0 +1,8 @@
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+# Use appointments to create fake lab results every minute
+# Load fake lab results into the PKY survey and serial projects every two minutes
+* * * * *   root /usr/bin/docker run --rm -it --env-file /ctsit/fr_covidata_engine/pky_dev.env fr_covidata_engine Rscript load_fake_data_into_upload.R
+* * * * *   root /usr/bin/docker run --rm -it --env-file /ctsit/fr_covidata_engine/pky_dev.env fr_covidata_engine Rscript load_fake_data_from_serial_into_upload.R
+*/2 * * * * root /usr/bin/docker run --rm -it --env-file /ctsit/fr_covidata_engine/pky_dev.env fr_covidata_engine Rscript load_results_into_pky_projects.R

--- a/examples/fr_covidata_engine_pky_prod.cron
+++ b/examples/fr_covidata_engine_pky_prod.cron
@@ -2,4 +2,4 @@ SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
 # Load lab results into the PKY survey and serial projects every 15 minutes from 5 p.m. - 11 p.m. Mon-Sat
-*/15 17-23 * * 1-6 root /usr/bin/docker run --rm -it --env-file /ctsit/fr_covidata_engine/pky_prod.env fr_covidata_engine Rscript load_results_into_pky_projects.R
+*/15 17-23 * * 1-6 root /usr/bin/docker run --rm --env-file /ctsit/fr_covidata_engine/pky_prod.env fr_covidata_engine Rscript load_results_into_pky_projects.R

--- a/examples/fr_covidata_engine_pky_prod.cron
+++ b/examples/fr_covidata_engine_pky_prod.cron
@@ -1,0 +1,5 @@
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+# Load lab results into the PKY survey and serial projects every 15 minutes from 5 p.m. - 11 p.m. Mon-Sat
+*/15 17-23 * * 1-6 root /usr/bin/docker run --rm -it --env-file /ctsit/fr_covidata_engine/pky_prod.env fr_covidata_engine Rscript load_results_into_pky_projects.R

--- a/load_fake_data_from_serial_into_upload.R
+++ b/load_fake_data_from_serial_into_upload.R
@@ -6,29 +6,30 @@ library(REDCapR)
 Sys.setenv(TZ = Sys.getenv("TIME_ZONE"))
 Sys.getenv("INSTANCE")
 
-records <- redcap_read_oneshot(redcap_uri = 'https://redcap.ctsi.ufl.edu/redcap/api/',
-                               token = Sys.getenv("SERIAL_TOKEN"))$data %>% 
-  filter(!is.na(research_encounter_id)) %>% 
-  filter(is.na(covid_19_swab_result)) %>%
-  select(research_encounter_id, covid_19_swab_result)
+# read data from the serial project...if there is any
+serial_project_read_all <- redcap_read_oneshot(redcap_uri = 'https://redcap.ctsi.ufl.edu/redcap/api/',
+                                           token = Sys.getenv("SERIAL_TOKEN"))
+if(serial_project_read_all$success) {
+  records <- serial_project_read_all$data %>%
+    filter(!is.na(research_encounter_id)) %>%
+    filter(is.na(covid_19_swab_result)) %>%
+    select(research_encounter_id, covid_19_swab_result)
+  # note the number of records we have so we can make samples of the same size
+  n <- nrow(records)
 
-# note the number of records we have so we can make samples of the same size
-n <- nrow(records)
+  # make some fake test results
+  results <- records %>%
+    mutate(covid_19_swab_result = case_when(
+      as.integer(str_remove_all(research_encounter_id, "[a-fA-F-]")) %% 2 == 0 ~ "Negative",
+      TRUE ~ "Positive"
+    )
+    ) %>%
+    rename(record_id  = research_encounter_id)
 
-# make some fake test results
-results <- records %>%
-  mutate(covid_19_swab_result = case_when(
-    as.integer(str_remove_all(research_encounter_id, "[a-fA-F-]")) %% 2 == 0 ~ "Negative",
-    TRUE ~ "Positive"
-  )
-  ) %>%
-  rename(record_id  = research_encounter_id)
-
-# Write data into the results project if it's safe to do so
-if (Sys.getenv("INSTANCE") == "Development") {
-  redcap_write_oneshot(results, 
-                       redcap_uri = 'https://redcap.ctsi.ufl.edu/redcap/api/',
-                       token = Sys.getenv("RESULT_TOKEN"))
+  # Write data into the results project if it's safe to do so
+  if (Sys.getenv("INSTANCE") == "Development") {
+    redcap_write_oneshot(results,
+                         redcap_uri = 'https://redcap.ctsi.ufl.edu/redcap/api/',
+                         token = Sys.getenv("RESULT_TOKEN"))
+  }
 }
-
-


### PR DESCRIPTION
This PR builds a container that has all of the fr_covidata_engine scripts in it and provides examples of how to use them. 

The revised Dockerfile sequences the build moire efficiently to allow quick rebuilds when scripts are updated. This Dockerfile does not run any of these scripts when run without parameters, but only enumerates them. Example and docs show how to run the scripts with a command and parameters. Cronjob examples are exact copies of how these would be run on a CTS-IT host.

This PR also revealed some issues when running the ETL scripts against empty redcap projects. A few conditionals and mutates addressed that problem in the effected scripts.